### PR TITLE
committer-name and committer-email inputs added

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ See the `fast-glob` [documentation][glob-docs] for glob syntax.
 -   `allow-dot`: allow glob patterns to match entries that begin with a period (`false` by default)
 -   `allow-removing`: allow to remove file if local copy is missing
     (`false` by default)
--   `commiter-name`: The name of the author (or committer) of the commit. (`github-actions[bot]` by default)
--   `commiter-email`: The email of the author (or committer) of the commit. (`github-actions[bot]@users.noreply.github.com` by default)
+-   `committer-name`: The name of the author (or committer) of the commit. (`github-actions[bot]` by default)
+-   `committer-email`: The email of the author (or committer) of the commit. (`github-actions[bot]@users.noreply.github.com` by default)
 
 Note that the action will produce an error if a local copy of a given file is missing, and the `allow-removing` flag is `false`.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ See the `fast-glob` [documentation][glob-docs] for glob syntax.
 -   `allow-dot`: allow glob patterns to match entries that begin with a period (`false` by default)
 -   `allow-removing`: allow to remove file if local copy is missing
     (`false` by default)
+-   `commiter-name`: The name of the author (or committer) of the commit. (`github-actions[bot]` by default)
+-   `commiter-email`: The email of the author (or committer) of the commit. (`github-actions[bot]@users.noreply.github.com` by default)
 
 Note that the action will produce an error if a local copy of a given file is missing, and the `allow-removing` flag is `false`.
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,17 @@ inputs:
     desciption: Allow to remove file
     default: false
     required: false
+
+  commiter-name:
+    description: The name of the author (or committer) of the commit
+    default: 'github-actions[bot]'
+    required: false
+
+  commiter-email:
+    description: The email of the author (or committer) of the commit
+    default: 'github-actions[bot]@users.noreply.github.com'
+    required: false
+
 runs:
   using: node12
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,12 @@ inputs:
     default: false
     required: false
 
-  commiter-name:
+  committer-name:
     description: The name of the author (or committer) of the commit
     default: 'github-actions[bot]'
     required: false
 
-  commiter-email:
+  committer-email:
     description: The email of the author (or committer) of the commit
     default: 'github-actions[bot]@users.noreply.github.com'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -97,6 +97,8 @@ class Updater {
         this.octokit = octokit_1.createOctokit(options.token);
         this.message = options.message;
         this.defaultBranch = options.branch || null;
+        this.commiterName = options.commiterName;
+        this.commiterEmail = options.commiterEmail;
     }
     async updateFiles(paths) {
         const branch = await this.getBranch();
@@ -114,7 +116,10 @@ class Updater {
     async createCommit(tree, parent) {
         const { message } = this;
         const { data } = await this.octokit.git.createCommit(Object.assign(Object.assign({}, github_1.context.repo), { message,
-            tree, parents: [parent] }));
+            tree, parents: [parent], author: {
+                name: this.commiterName,
+                email: this.commiterEmail,
+            } }));
         return data.sha;
     }
     async createTree(branch, filePaths, base_tree) {
@@ -224,7 +229,9 @@ function getActionOptions() {
     const token = core_1.getInput('github-token', { required: true });
     const message = core_1.getInput('commit-msg', { required: true });
     const branch = core_1.getInput('branch');
-    return { token, message, branch };
+    const commiterName = core_1.getInput('commiter-name');
+    const commiterEmail = core_1.getInput('commiter-email');
+    return { token, message, branch, commiterName, commiterEmail };
 }
 exports.getActionOptions = getActionOptions;
 function isNotNull(arg) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -97,8 +97,8 @@ class Updater {
         this.octokit = octokit_1.createOctokit(options.token);
         this.message = options.message;
         this.defaultBranch = options.branch || null;
-        this.commiterName = options.commiterName;
-        this.commiterEmail = options.commiterEmail;
+        this.committerName = options.committerName;
+        this.committerEmail = options.committerEmail;
     }
     async updateFiles(paths) {
         const branch = await this.getBranch();
@@ -117,8 +117,8 @@ class Updater {
         const { message } = this;
         const { data } = await this.octokit.git.createCommit(Object.assign(Object.assign({}, github_1.context.repo), { message,
             tree, parents: [parent], author: {
-                name: this.commiterName,
-                email: this.commiterEmail,
+                name: this.committerName,
+                email: this.committerEmail,
             } }));
         return data.sha;
     }
@@ -229,9 +229,9 @@ function getActionOptions() {
     const token = core_1.getInput('github-token', { required: true });
     const message = core_1.getInput('commit-msg', { required: true });
     const branch = core_1.getInput('branch');
-    const commiterName = core_1.getInput('commiter-name');
-    const commiterEmail = core_1.getInput('commiter-email');
-    return { token, message, branch, commiterName, commiterEmail };
+    const committerName = core_1.getInput('committer-name');
+    const committerEmail = core_1.getInput('committer-email');
+    return { token, message, branch, committerName, committerEmail };
 }
 exports.getActionOptions = getActionOptions;
 function isNotNull(arg) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -32,12 +32,16 @@ export class Updater {
 	private octokit: InstanceType<typeof GitHub>;
 	private message: string;
 	private defaultBranch: string | null;
+	private commiterName: string;
+	private commiterEmail: string;
 
 	constructor(options: UpdaterOptions) {
 		this.octokit = createOctokit(options.token);
 
 		this.message = options.message;
 		this.defaultBranch = options.branch || null;
+		this.commiterName = options.commiterName;
+		this.commiterEmail = options.commiterEmail;
 	}
 
 	async updateFiles(paths: string[]): Promise<UpdateResult | null> {
@@ -66,6 +70,10 @@ export class Updater {
 			message,
 			tree,
 			parents: [parent],
+			author: {
+				name: this.commiterName,
+				email: this.commiterEmail,
+			},
 		});
 
 		return data.sha;

--- a/src/update.ts
+++ b/src/update.ts
@@ -32,16 +32,16 @@ export class Updater {
 	private octokit: InstanceType<typeof GitHub>;
 	private message: string;
 	private defaultBranch: string | null;
-	private commiterName: string;
-	private commiterEmail: string;
+	private committerName: string;
+	private committerEmail: string;
 
 	constructor(options: UpdaterOptions) {
 		this.octokit = createOctokit(options.token);
 
 		this.message = options.message;
 		this.defaultBranch = options.branch || null;
-		this.commiterName = options.commiterName;
-		this.commiterEmail = options.commiterEmail;
+		this.committerName = options.committerName;
+		this.committerEmail = options.committerEmail;
 	}
 
 	async updateFiles(paths: string[]): Promise<UpdateResult | null> {
@@ -71,8 +71,8 @@ export class Updater {
 			tree,
 			parents: [parent],
 			author: {
-				name: this.commiterName,
-				email: this.commiterEmail,
+				name: this.committerName,
+				email: this.committerEmail,
 			},
 		});
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,8 +5,8 @@ export interface UpdaterOptions {
 	branch: string;
 	token: string;
 	message: string;
-	commiterName: string;
-	commiterEmail: string;
+	committerName: string;
+	committerEmail: string;
 }
 
 export function getBooleanInput(name: string, options?: InputOptions): boolean {
@@ -37,10 +37,10 @@ export function getActionOptions(): UpdaterOptions {
 	const token = getInput('github-token', { required: true });
 	const message = getInput('commit-msg', { required: true });
 	const branch = getInput('branch');
-	const commiterName = getInput('commiter-name');
-	const commiterEmail = getInput('commiter-email');
+	const committerName = getInput('committer-name');
+	const committerEmail = getInput('committer-email');
 
-	return { token, message, branch, commiterName, commiterEmail };
+	return { token, message, branch, committerName, committerEmail };
 }
 
 export function isNotNull<T>(arg: T): arg is Exclude<T, null> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,8 @@ export interface UpdaterOptions {
 	branch: string;
 	token: string;
 	message: string;
+	commiterName: string;
+	commiterEmail: string;
 }
 
 export function getBooleanInput(name: string, options?: InputOptions): boolean {
@@ -35,8 +37,10 @@ export function getActionOptions(): UpdaterOptions {
 	const token = getInput('github-token', { required: true });
 	const message = getInput('commit-msg', { required: true });
 	const branch = getInput('branch');
+	const commiterName = getInput('commiter-name');
+	const commiterEmail = getInput('commiter-email');
 
-	return { token, message, branch };
+	return { token, message, branch, commiterName, commiterEmail };
 }
 
 export function isNotNull<T>(arg: T): arg is Exclude<T, null> {


### PR DESCRIPTION
First I would like to congratulate you on the great work you have done to make this action works excellent. I found a possible improvement and decided to implement to solve a problem that I had in my workflows.

## 🎯 The problem
Within my configuration I needed to forcefully pass the PAT (Personal Access Token) token to all the actions that would need write access to the repository.

This works fine but the problem is that the account of the user who generated the token is used as the author of the changes.

![image](https://user-images.githubusercontent.com/57654255/143989301-07c02b27-1ed5-4ae2-9440-74139407a3fa.png)


This is my configuration file:

``` yaml
    - name: Update resources
      uses: test-room-7/action-update-file@v1
      with:
        github-token: ${{ secrets.PAT }}
        file-path: .github/screenshot.png
        commit-msg: 'docs: screenshot update [skip ci]'
```


## 🙌 Solution
To solve this issue, I added the `committer-name` and `committer-email` entries so that I can use another account as the author. For example, `github-actions [bot]`

The new entries are optional and do not affect the settings of this action in other repositories.

| Variable | Required | Default | Description |
| --- | --- | --- | --- |
| `committer-name` | false | `github-actions[bot]` | The name of the author (or committer) of the commit |
| `committer-email` | false | `github-actions[bot]@users.noreply.github.com` | The email of the author (or committer) of the commit |

With these new inputs, the action now uses the `github-actions [bot]` account by default to create commits, although it can be changed to any other account by passing the values ​​when configuring the action.

![image](https://user-images.githubusercontent.com/57654255/143990688-fd8a5a15-9de3-441e-a17c-71005fd94b8a.png)


## 📜 Documentation
I have added to the README.md file the documentation of the new entries. You can find them in the `optional inputs` section

[https://github.com/luisfalconmx/action-update-file#optional-inputs](https://github.com/luisfalconmx/action-update-file#optional-inputs)

---

I have already tested this change and it works fine. I await any comments or questions you may have. 😉