### PR TITLE
update to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     required: false
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: git-commit


### PR DESCRIPTION
updating node to 16 based on this: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/